### PR TITLE
fix: correct import paths for leaflet-geotiff-2 plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Dependencies must be loaded:
 import "leaflet-geotiff-2";
 
 // optional renderers
-import "leaflet-geotiff-2/dist/leaflet-geotiff-rgb";
-import "leaflet-geotiff-2/dist/leaflet-geotiff-vector-arrows";
-import "leaflet-geotiff-2/dist/leaflet-geotiff-plotty"; // requires plotty
+import "leaflet-geotiff-2/leaflet-geotiff-rgb";
+import "leaflet-geotiff-2/leaflet-geotiff-vector-arrows";
+import "leaflet-geotiff-2/leaflet-geotiff-plotty"; // requires plotty
 ```
 
 ### 2. Add a geoTIFF layer


### PR DESCRIPTION
The README specifies using the package’s exported subpaths rather than deep imports. This ensures compatibility with the package's "exports" field and prevents “Module not found” errors when building.

Also, please add the package to npmjs